### PR TITLE
Using HashRouter instead of BrowserRouter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { Routes, Route, HashRouter } from 'react-router-dom';
 import Home from './pages/Home';
 import { CssVarsProvider } from '@mui/joy/styles';
 import SkylinePage from './pages/SkylinePage';
@@ -6,13 +6,13 @@ import SkylinePage from './pages/SkylinePage';
 function App() {
 	return (
 		<CssVarsProvider>
-			<Router>
+			<HashRouter>
 				<Routes>
 					<Route path="/" Component={Home} />
 					<Route path="/skyline" Component={Home} />
 					<Route path="/skyline/:username" Component={SkylinePage} />
 				</Routes>
-			</Router>
+			</HashRouter>
 		</CssVarsProvider>
 	);
 }

--- a/src/components/UsernameSearchBar.tsx
+++ b/src/components/UsernameSearchBar.tsx
@@ -15,7 +15,7 @@ function UsernameSearchBar() {
 			setErrorMessage(`Please enter a username.`);
 			return;
 		}
-		window.location.href = `/skyline/${username}`;
+		window.location.href = `#/skyline/${username}`;
 	}
 
 	return (

--- a/src/pages/SkylinePage.tsx
+++ b/src/pages/SkylinePage.tsx
@@ -15,7 +15,7 @@ function SkylinePage() {
 
 	useEffect(() => {
 		if (!username || username === "") {
-			window.location.href = `/skyline?err=${encodeURIComponent("Please enter a username")}`
+			window.location.href = `#/skyline?err=${encodeURIComponent("Please enter a username")}`
 			setErrorMessage(`No username provided!`);
 			return;
 		}
@@ -25,7 +25,7 @@ function SkylinePage() {
 				const userTimeline = generateContributionTimeline(userEvents);
 				if (!userTimeline) {
 					const errorMessage = `We did not find any @${username} on GitHub, try it again.`
-					window.location.href = `/skyline?err=${encodeURIComponent(errorMessage)}`
+					window.location.href = `#/skyline?err=${encodeURIComponent(errorMessage)}`
 					setErrorMessage(`Username not found!`);
 					return;
 				}
@@ -35,7 +35,7 @@ function SkylinePage() {
 			.catch((err: Error) => {
 				console.error('Error in getting data:', err);
 				const errorMsg = `Error in getting data: ${err.message}`
-				window.location.href = `/skyline?err=${encodeURIComponent(errorMsg)}`
+				window.location.href = `#/skyline?err=${encodeURIComponent(errorMsg)}`
 				setErrorMessage(errorMsg);
 			})
 	}, [username])


### PR DESCRIPTION
This is not recommended because HashRouter was mostly used for legacy browsers and BrowserRouter is supported by all modern browsers.
But GitHub Pages don't support BrowserRouter.

TODO: If we host this website anywhere else, we would ideally want to revert this change.