### PR TITLE
Fix: GitHub API does not provide more than a year of data - this error was coming when querying for Sundays in leap years.

### DIFF
--- a/src/utils/generateContributionTimeline.ts
+++ b/src/utils/generateContributionTimeline.ts
@@ -84,3 +84,26 @@ export const getFirstDayOfYearFromLastDay = (lastDay: Date) => {
 	firstDay.setDate(firstDay.getDate() + 1);
 	return firstDay;
 }
+
+/**
+ * NOTE: This function only exists because GitHub API does not understand leap years are longer than 365 days (and creates problems with the contribution timeline)
+ * @param date current date
+ * @returns the date of the previous day (same time)
+ */
+export const getPreviousDate = (date: Date) => {
+	const newDate = new Date(date);
+	newDate.setDate(date.getDate() - 1);
+	return newDate;
+}
+
+/**
+ * Identifies if the 1-year period before this date has a leap day (February 29th)
+ *
+ * NOTE: This function only exists because GitHub API does not understand leap years are longer than 365 days (and creates problems with the contribution timeline)
+ * @param endDate last day of the 1-year range
+ */
+export const hasLeapDayInRange = (endDate: Date) => {
+	const febYear = endDate.getMonth() > 1 ? endDate.getFullYear() : endDate.getFullYear() - 1;
+	const february = new Date(febYear, 1, 29);
+	return february.getMonth() === 1;
+}

--- a/src/utils/getUserContributions.ts
+++ b/src/utils/getUserContributions.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { GitHubContributionCalendar } from '../github-types';
-import { getFirstDayOfYearFromLastDay, getSaturdayOfWeek, getSundayOfWeek } from './generateContributionTimeline';
+import { getFirstDayOfYearFromLastDay, getPreviousDate, getSaturdayOfWeek, getSundayOfWeek, hasLeapDayInRange } from './generateContributionTimeline';
 
 const axiosInstance = axios.create({
 	baseURL: 'https://api.github.com',
@@ -24,7 +24,9 @@ type UserContributionsResponseType = {
 export const getUserContributions = async (username: string, endDate: Date) => {
 	const startDate = getFirstDayOfYearFromLastDay(endDate);
 	const rangeStartDate = getSundayOfWeek(startDate);
-	const rangeEndDate = getSaturdayOfWeek(endDate);
+	const rangeEndDate = hasLeapDayInRange(endDate) && endDate.getDay() === 0 // if Leap Year and Sunday (FIX FOR: GitHub API does not understand leap years are longer than 365 days)
+		? getPreviousDate(endDate) // guaranteed to be Saturday
+		: getSaturdayOfWeek(endDate);
 	const query = `
   {
     user(login: "${username}") {
@@ -45,6 +47,10 @@ export const getUserContributions = async (username: string, endDate: Date) => {
 `;
 	try {
 		const response = await axiosInstance.post<UserContributionsResponseType>("/graphql", { query });
+		if (response.status !== 200) {
+			console.error('Error fetching user contributions:', response.status, response.statusText);
+			throw new Error(`Failed to fetch user contributions: Response status ${response.status}`);
+		}
 		const userContributions = response.data.data.user.contributionsCollection.contributionCalendar;
 		return userContributions;
 	} catch (error) {


### PR DESCRIPTION
Add functions to handle leap years in contribution timeline calculations (because GitHub GraphQL API does not understand that leap years are longer than 365 days)